### PR TITLE
Support reverse proxies with new configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,13 @@ var_dump($result);
 
 Configuration
 -------------
-The configuration object has now has 1 option from the 3 that were in v1:
+Two parameters can be passed to the `Configuration` object:
 - **steam_key**, the API key you can get from [http://steamcommunity.com/dev/apikey](http://steamcommunity.com/dev/apikey).
+- **base_steam_api_url**, an optional parameter to override `http://api
+.steampowered.com` as the base API URL. 
 
-As shown above you set the steam by passing it into the Configuration constructor:
+As shown above you can set the Steam API key by passing it into the 
+`Configuration` constructor:
 
 ```php
 $steam = new Steam(new Configuration([

--- a/src/Steam/Configuration.php
+++ b/src/Steam/Configuration.php
@@ -7,12 +7,14 @@ use Steam\Exception\InvalidConfigOptionException;
 class Configuration
 {
     const STEAM_KEY = 'steam_key';
+    const BASE_STEAM_API_URL = 'base_steam_api_url';
 
     /**
      * @var array
      */
     protected $_options = array(
         self::STEAM_KEY => '',
+        self::BASE_STEAM_API_URL => 'http://api.steampowered.com'
     );
 
     /**
@@ -60,6 +62,6 @@ class Configuration
      */
     public function getBaseSteamApiUrl()
     {
-        return 'http://api.steampowered.com';
+        return $this->_options[self::BASE_STEAM_API_URL];
     }
 }


### PR DESCRIPTION
Some projects like to access the Steam web APIs via a reverse proxy, so the base API URL may differ in these cases.

This change allows for the usage of this library without needing to write a custom Runner implementation.