### PR TITLE
Add GetSchemaItems/GetSchemaOverview, deprecated GetSchema

### DIFF
--- a/src/Steam/Command/EconItems/GetSchemaItems.php
+++ b/src/Steam/Command/EconItems/GetSchemaItems.php
@@ -78,7 +78,7 @@ class GetSchemaItems implements CommandInterface
         $params = [];
 
         empty($this->language) ?: $params['language'] = $this->language;
-        $params['start'] = $this->start ?: 0;
+        empty($this->start) ?: $params['start'] = $this->start;
 
         return $params;
     }

--- a/src/Steam/Command/EconItems/GetSchemaItems.php
+++ b/src/Steam/Command/EconItems/GetSchemaItems.php
@@ -4,10 +4,7 @@ namespace Steam\Command\EconItems;
 
 use Steam\Command\CommandInterface;
 
-/**
- * @deprecated Has been removed by Valve; use GetSchemaItems/GetSchemaOverview
- */
-class GetSchema implements CommandInterface
+class GetSchemaItems implements CommandInterface
 {
     /**
      * @var int
@@ -18,6 +15,11 @@ class GetSchema implements CommandInterface
      * @var string
      */
     protected $language;
+
+    /**
+     * @var string
+     */
+    protected $start;
 
     /**
      * @param int $appId
@@ -38,6 +40,19 @@ class GetSchema implements CommandInterface
         return $this;
     }
 
+    /**
+     * The first item id to return. Defaults to 0. Response will indicate next value to query if applicable.
+     *
+     * @param int $start
+     *
+     * @return self
+     */
+    public function setStart($start)
+    {
+        $this->start = $start;
+        return $this;
+    }
+
     public function getInterface()
     {
         return 'IEconItems_' . $this->appId;
@@ -45,7 +60,7 @@ class GetSchema implements CommandInterface
 
     public function getMethod()
     {
-        return 'GetSchema';
+        return 'GetSchemaItems';
     }
 
     public function getVersion()
@@ -63,6 +78,7 @@ class GetSchema implements CommandInterface
         $params = [];
 
         empty($this->language) ?: $params['language'] = $this->language;
+        $params['start'] = $this->start ?: 0;
 
         return $params;
     }

--- a/src/Steam/Command/EconItems/GetSchemaOverview.php
+++ b/src/Steam/Command/EconItems/GetSchemaOverview.php
@@ -4,10 +4,7 @@ namespace Steam\Command\EconItems;
 
 use Steam\Command\CommandInterface;
 
-/**
- * @deprecated Has been removed by Valve; use GetSchemaItems/GetSchemaOverview
- */
-class GetSchema implements CommandInterface
+class GetSchemaOverview implements CommandInterface
 {
     /**
      * @var int
@@ -45,7 +42,7 @@ class GetSchema implements CommandInterface
 
     public function getMethod()
     {
-        return 'GetSchema';
+        return 'GetSchemaOverview';
     }
 
     public function getVersion()

--- a/tests/src/Steam/Command/EconItems/GetSchemaItemsTest.php
+++ b/tests/src/Steam/Command/EconItems/GetSchemaItemsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Steam\Command\EconItems;
+
+use Steam\Command\CommandInterface;
+
+class GetSchemaItemsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var GetSchemaItems
+     */
+    protected $instance;
+
+    public function setUp()
+    {
+        $this->instance = new GetSchemaItems(123);
+    }
+
+    public function testImplementsInterface()
+    {
+        $this->assertTrue($this->instance instanceof CommandInterface);
+    }
+
+    public function testValues()
+    {
+        $this->assertEquals('IEconItems_123', $this->instance->getInterface());
+        $this->assertEquals('GetSchemaItems', $this->instance->getMethod());
+        $this->assertEquals('v1', $this->instance->getVersion());
+        $this->assertEquals('GET', $this->instance->getRequestMethod());
+        $this->assertEquals([], $this->instance->getParams());
+    }
+
+    public function testSettingLanguageAppearsInParams()
+    {
+        $this->instance->setLanguage('en');
+
+        $this->assertEquals(['language' => 'en'], $this->instance->getParams());
+    }
+
+    public function testSettingStartUpdatesInParams()
+    {
+        $this->instance->setStart(50);
+
+        $this->assertEquals(['start' => 50], $this->instance->getParams());
+    }
+}
+ 

--- a/tests/src/Steam/Command/EconItems/GetSchemaOverviewTest.php
+++ b/tests/src/Steam/Command/EconItems/GetSchemaOverviewTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Steam\Command\EconItems;
+
+use Steam\Command\CommandInterface;
+
+class GetSchemaOverviewTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var GetSchemaOverview
+     */
+    protected $instance;
+
+    public function setUp()
+    {
+        $this->instance = new GetSchemaOverview(123);
+    }
+
+    public function testImplementsInterface()
+    {
+        $this->assertTrue($this->instance instanceof CommandInterface);
+    }
+
+    public function testValues()
+    {
+        $this->assertEquals('IEconItems_123', $this->instance->getInterface());
+        $this->assertEquals('GetSchemaOverview', $this->instance->getMethod());
+        $this->assertEquals('v1', $this->instance->getVersion());
+        $this->assertEquals('GET', $this->instance->getRequestMethod());
+        $this->assertEquals([], $this->instance->getParams());
+    }
+
+    public function testSettingLanguageAppearsInParams()
+    {
+        $this->instance->setLanguage('en');
+
+        $this->assertEquals(['language' => 'en'], $this->instance->getParams());
+    }
+}
+ 


### PR DESCRIPTION
Valve have deprecated IEconItems_*/GetSchema and replaced it with two new APIs; one of these is a cursor-like API for the items list, and the other is the remaining information.

This commit adds the two command stubs and marks the GetSchema command as deprecated.